### PR TITLE
스플래시 화면에서 상태바가 흰색으로 표시되는 문제 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ export type RootStackParamList = {
 export default function App() {
     return (
         <SafeAreaProvider>
+            <StatusBar translucent />
             <NavigationContainer>
                 <TabNavigator />
             </NavigationContainer>


### PR DESCRIPTION
## 🔥 연관 이슈

- close #이슈번호

## 🚀 작업 내용

- 스플래시 화면을 포함한 몇몇 화면에서 StatusBar의 배경색이 흰색으로 표시되어 상태 표시줄의 내용을 보지 못하는 내용을 수정 했습니다.

## 💬 리뷰 중점사항
